### PR TITLE
The app info tab should show the info available.

### DIFF
--- a/nbextensions/appCell2/widgets/tabs/infoTab.js
+++ b/nbextensions/appCell2/widgets/tabs/infoTab.js
@@ -64,13 +64,22 @@ define([
             const description = document.createTextNode(appSpec.info.subtitle);
 
             // AVERAGE RUNTIME
-            const executionStats = model.getItem('executionStats');
-            const avgRuntime = format.niceDuration(1000*(
-                executionStats.total_exec_time/executionStats.number_of_calls
-            ));
-            const runtimeAvgListItem = DOMTagLI(
-                `The average execution time for this app is ${avgRuntime}.`
-            );
+            const execStats = model.getItem('executionStats');
+            let avgRuntime;
+            if( execStats
+                && execStats.total_exec_time
+                && execStats.number_of_calls > 0
+            ) {
+                avgRuntime = format.niceDuration(1000*(
+                    execStats.total_exec_time/execStats.number_of_calls
+                ));
+            }
+            let runtimeAvgListItem = document.createTextNode('');
+            if(avgRuntime) {
+                runtimeAvgListItem = DOMTagLI(
+                    `The average execution time for this app is ${avgRuntime}.`
+                );
+            }
 
             // LIST OF PARAMETERS
             const parametersList = document.createElement('ul');
@@ -156,6 +165,7 @@ define([
         }
 
         return {
+            hide: () => {},
             start: start,
             stop: stop
         };


### PR DESCRIPTION
If execution stats are not available then do not show them, but show the rest of the information available.

This diff should fix at least that bug. You can add this to PR #1744 on kbase/narrative.